### PR TITLE
ダークモード時のcode styleの背景色と文字色が同系色になる問題の修正

### DIFF
--- a/src/content_scripts/style.css
+++ b/src/content_scripts/style.css
@@ -273,10 +273,8 @@ details.hold-images summary {
 	--md-background-color: #f0f0f0;
 }
 
-@media (prefers-color-scheme: dark) {
-	:root {
-		--md-background-color: #303030;
-	}
+[data-theme="dark"] {
+	--md-background-color: #303030;
 }
 
 .markdown-code-style-gfm pre {

--- a/src/content_scripts/style.css
+++ b/src/content_scripts/style.css
@@ -269,15 +269,25 @@ details.hold-images summary {
 /* **********************************************
  * Markdown
  ************************************************ */
+:root {
+	--md-background-color: #f0f0f0;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--md-background-color: #303030;
+	}
+}
+
 .markdown-code-style-gfm pre {
 	padding: 8px;
 	white-space: pre-wrap;
-	background-color: #f0f0f0;
+	background-color: var(--md-background-color);
 }
 
 .markdown-code-style-gfm code:not(.markdown-code-style-gfm pre code) {
 	padding: 0 4px !important;
-	background-color: #f0f0f0 !important;
+	background-color: var(--md-background-color) !important;
 	color: #ff3333 !important;
 }
 


### PR DESCRIPTION
ダークモードで使用しているときmarkdownのcode styleを使用すると，背景色も文字色も白系統の色になってしまい見にくかったので修正しました。

ダークモード時には #303030 になるようにしています。

色や変数名等，不都合があればご指摘 or 修正していただけると助かります。